### PR TITLE
Caused by java.lang.NoSuchMethodError

### DIFF
--- a/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java
+++ b/android/src/main/java/com/createthumbnail/CreateThumbnailModule.java
@@ -189,8 +189,17 @@ public class CreateThumbnailModule extends ReactContextBaseJavaModule {
             }
             retriever.setDataSource(filePath, headers);
         }
-  
-        Bitmap image = retriever.getScaledFrameAtTime(time * 1000, MediaMetadataRetriever.OPTION_CLOSEST_SYNC, maxWidth, maxHeight);
+
+        Bitmap image;
+        if (Build.VERSION.SDK_INT >= 27) {
+            image = retriever.getScaledFrameAtTime(time * 1000, MediaMetadataRetriever.OPTION_CLOSEST_SYNC, maxWidth, maxHeight);
+        } else {
+            // 如果在低于 API 27 的版本上，使用其他方法获取帧
+            image = retriever.getFrameAtTime(time * 1000, MediaMetadataRetriever.OPTION_CLOSEST_SYNC);
+            if (image != null) {
+                image = Bitmap.createScaledBitmap(image, maxWidth, maxHeight, true);
+            }
+        }
         try {
             retriever.release();
         } catch(IOException e) {


### PR DESCRIPTION
crash

```
         Fatal Exception: java.lang.RuntimeException: An error occurred while executing doInBackground()
       at android.os.AsyncTask$3.done(AsyncTask.java:353)
       at java.util.concurrent.FutureTask.finishCompletion(FutureTask.java:383)
       at java.util.concurrent.FutureTask.setException(FutureTask.java:252)
       at java.util.concurrent.FutureTask.run(FutureTask.java:271)
       at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:245)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
       at java.lang.Thread.run(Thread.java:764)
        
```